### PR TITLE
bin/create_img.sh: Update debootstrap command name

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Create and handle qemu-imgs that are suitable to perform kernel testing/developm
 
 ## Requirements
 
-`apt install qemu qemu-user-static debootstrap`
+`sudo apt install qemu-system qemu-user-static debootstrap`
 
 ## Usage
 

--- a/bin/create_img.sh
+++ b/bin/create_img.sh
@@ -30,15 +30,15 @@ fi
 MOUNTED=1
 sudo mount -o loop $IMG $TMP_DIR
 
-# Create the contens
+# Create the contents
 if [ "$ARCH" == "x86_64" ]; then
 	sudo debootstrap --arch amd64 stable $TMP_DIR
 elif [ "$ARCH" == "i386" ]; then
 	sudo debootstrap --arch i386 stable $TMP_DIR
 elif [ "$ARCH" == "aarch64" ]; then
-	sudo qemu-debootstrap --arch arm64 stable $TMP_DIR
+	sudo debootstrap --arch arm64 stable $TMP_DIR
 elif [ "$ARCH" == "arm" ]; then
-	sudo qemu-debootstrap --arch armel stable $TMP_DIR
+	sudo debootstrap --arch armel stable $TMP_DIR
 else
 	echo "ERROR: unknown arch $ARCH"
 	exit -1

--- a/bin/setup_img.sh
+++ b/bin/setup_img.sh
@@ -38,7 +38,7 @@ apt update
 echo "$ARCH_ROOT_HDA	/	auto	defaults	0	1" > /etc/fstab
 
 # Install some software we usually need
-apt install -y vim trace-cmd hwloc sudo $ARCH_PACKAGES
+apt install -y vim trace-cmd hwloc sudo linux-perf rt-tests $ARCH_PACKAGES
 
 # Install network and sshd packagers
 apt install -y net-tools ifupdown network-manager openssh-server

--- a/run_qemu
+++ b/run_qemu
@@ -11,13 +11,15 @@ function print_usage {
 	echo "Usage: $(basename $0) <path/to/kernel/image> [options]"
 	echo "	Options:"
 	echo "		--arch [arch]: x86_64(default)|i386|aarch64|arm"
+	echo "		--kvm: Enable KVM (only valid for Intel archs)"
 	echo "		-h|--help: print this help message"
 }
 
 ARCH=x86_64
+KVM=""
 
 SHORTOPTS="h"
-LONGOPTS="arch:,help"
+LONGOPTS="arch:,kvm,help"
 
 ARGS==`getopt -n "$(basename $0)" --options $SHORTOPTS --longoptions $LONGOPTS -- "$@"`
 
@@ -36,6 +38,9 @@ do
 			ARCH="$1"
 			;;
 
+		--kvm)
+			KVM="--enable-kvm"
+			;;
 		--)
 			shift
 			break
@@ -57,7 +62,7 @@ IMG=${IMG:-$(dirname $(realpath $0))/images/qemu-image-$ARCH.img}
 if [[ "$ARCH" == "x86_64" || "$ARCH" == "i386" ]]; then
 	ARCH_OPTS="					\
 		-drive file=$IMG,format=raw,file.locking=off \
-		--enable-kvm"
+		${KVM}"
 	CMD_LINE="root=/dev/sda console=ttyS0"
 elif [[ "$ARCH" == "aarch64" ]]; then
 	ARCH_OPTS="				\

--- a/run_qemu
+++ b/run_qemu
@@ -61,18 +61,18 @@ IMG=${IMG:-$(dirname $(realpath $0))/images/qemu-image-$ARCH.img}
 
 if [[ "$ARCH" == "x86_64" || "$ARCH" == "i386" ]]; then
 	ARCH_OPTS="					\
-		-drive file=$IMG,format=raw,file.locking=off \
+		-drive file=$IMG,format=raw,file.locking=off,snapshot=on \
 		${KVM}"
 	CMD_LINE="root=/dev/sda console=ttyS0"
 elif [[ "$ARCH" == "aarch64" ]]; then
 	ARCH_OPTS="				\
-		-drive file=$IMG,format=raw,file.locking=off \
+		-drive file=$IMG,format=raw,file.locking=off,snapshot=on \
 		-cpu cortex-a53			\
 		-machine virt"
 	CMD_LINE="root=/dev/vda"
 elif [[ "$ARCH" == "arm" ]]; then
 	ARCH_OPTS="				\
-		-drive if=none,file=$IMG,format=raw,id=hd \
+		-drive if=none,file=$IMG,format=raw,id=hd,snapshot=on \
 		-device virtio-blk-device,drive=hd	\
 		-cpu cortex-a15			\
 		-machine virt"

--- a/run_qemu
+++ b/run_qemu
@@ -82,8 +82,8 @@ sudo qemu-system-$ARCH				\
 	-kernel $KERNEL				\
 	-s \
 	-append "$CMD_LINE"			\
-	-smp cores=4,threads=2			\
+	-smp cores=6,threads=2			\
 	--nographic				\
-	-m 512					\
+	-m 1024					\
 	-net nic -net user,hostfwd=tcp::10022-:22 \
 	$ARCH_OPTS


### PR DESCRIPTION
qemu-debootstrap looks to be renamed to debootstrap on Ubuntu-23.10. Hence, rename its references.

Also fix a typo in bin/create_img.sh script and improve requirements in README.md.